### PR TITLE
Replace references to CIP with UIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Celestia Improvement Proposals (CIPs)
+# Penumbra Improvement Proposals (UIPs)
 
-See [/cips/README.md](./cips/README.md) for an overview of the CIP process.
+See [/uips/README.md](./uips/README.md) for an overview of the UIP process.
 
-See the [WGs directory](./cips/wgs/README.md) for Working Groups within the CIP process.
+See the [WGs directory](./uips/wgs/README.md) for Working Groups within the UIP process.

--- a/uips/README.md
+++ b/uips/README.md
@@ -4,17 +4,17 @@ Read [UIP-1](./uip-1.md) for information on the UIP process.
 
 ## Meetings
 
-| №  |       Date        |                          Agenda                          |                                   Notes                                   |                            Recording                            |
-|:--:|:-----------------:|:--------------------------------------------------------:|:-------------------------------------------------------------------------:|:---------------------------------------------------------------:|
-| | |  | | |
+|  №  | Date | Agenda | Notes | Recording |
+| :-: | :--: | :----: | :---: | :-------: |
+|     |      |        |       |           |
 
 ## Penumbra Improvement Proposals (UIPs)
 
-|         №         |                                    Title                                     |                                                                       Author(s)                                                                        |
-|:-----------------:|:----------------------------------------------------------------------------:|:------------------------------------------------------------------------------------------------------------------------------------------------------:|
-|  [1](./uip-1.md)  |             Penumbra Improvement Proposal Process and Guidelines             |                                                             Henry de Valence <hdevalence@penumbralabs.xyz>                                                              |
-|  [2](./uip-2.md)  |                             CIP Editor Handbook                              |                                                                 Henry de Valence <hdevalence@penumbralabs.xyz>                                                                 |
-|  [3](./uip-3.md)  |                             Process for Approving External Resources         |                                                                 Henry de Valence <hdevalence@penumbralabs.xyz>                                                                 |
+|        №        |                        Title                         |                   Author(s)                    |
+| :-------------: | :--------------------------------------------------: | :--------------------------------------------: |
+| [1](./uip-1.md) | Penumbra Improvement Proposal Process and Guidelines | Henry de Valence <hdevalence@penumbralabs.xyz> |
+| [2](./uip-2.md) |                 UIP Editor Handbook                  | Henry de Valence <hdevalence@penumbralabs.xyz> |
+| [3](./uip-3.md) |       Process for Approving External Resources       | Henry de Valence <hdevalence@penumbralabs.xyz> |
 
 ## Contributing
 

--- a/uips/uip-1.md
+++ b/uips/uip-1.md
@@ -1,10 +1,10 @@
-| cip | 1 |
-| - | - |
-| title | Penumbra Improvement Proposal Process and Guidelines |
-| author | Henry de Valence <hdevalence@penumbralabs.xyz> |
-| status | Living |
-| type | Meta |
-| created | 2024-11-01 |
+| uip     | 1                                                    |
+| ------- | ---------------------------------------------------- |
+| title   | Penumbra Improvement Proposal Process and Guidelines |
+| author  | Henry de Valence <hdevalence@penumbralabs.xyz>       |
+| status  | Living                                               |
+| type    | Meta                                                 |
+| created | 2024-11-01                                           |
 
 ## Table of Contents
 
@@ -296,14 +296,14 @@ the following parts:
   addressed. UIP submissions lacking a "Privacy Considerations" section
   will be rejected. A UIP cannot reach "Final" status without a Pecurity
   Considerations discussion deemed sufficient by the reviewers.
-* **Copyright Waiver**: All UIPs must be in the public domain. The
+- **Copyright Waiver**: All UIPs must be in the public domain. The
   copyright waiver MUST link to the license file and use the following
   wording: Copyright and related rights waived via CC0.
 
 ## UIP Formats and Templates
 
 UIPs should be written in [markdown](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet)
-format. There is a [UIP template](./cip-template.md) to follow.
+format. There is a [UIP template](./uip-template.md) to follow.
 
 ## UIP Header Preamble
 
@@ -312,10 +312,10 @@ markdown table.
 In order to display on the UIP site, the frontmatter must be formatted
 in a markdown table. The headers must appear in the following order:
 
-* `cip`: UIP number (this is determined by the UIP editor)
-* `title`: The UIP title is a few words, not a complete sentence
-* `description`: Description is one full (short) sentence
-* `author`: The list of the author’s or authors’ name(s) and/or
+- `uip`: UIP number (this is determined by the UIP editor)
+- `title`: The UIP title is a few words, not a complete sentence
+- `description`: Description is one full (short) sentence
+- `author`: The list of the author’s or authors’ name(s) and/or
   username(s), or name(s) and email(s). Details are below.
 * `discussions-to`: The url pointing to the official discussion thread
 * `status`: Draft, Review, Last Call, Final, Stagnant, Withdrawn, Living
@@ -419,7 +419,7 @@ For example, you would link to this UIP as `./uip-1.md`.
 
 Images, diagrams and auxiliary files should be included in a
 subdirectory of the `assets` folder for that UIP as follows:
-`assets/cip-N` (where **N** is to be replaced with the UIP
+`assets/uip-N` (where **N** is to be replaced with the UIP
 number). When linking to an image in the UIP, use relative
 links such as `../assets/uip-1/image.png`.
 
@@ -450,7 +450,7 @@ The current UIP editors are
 * Henry de Valence ([@hdevalence](https://github.com/hdevalence))
 * Finch ([@plaidfinch](https://github.com/plaidfinch))
 
-If you would like to become a UIP editor, please check [UIP-2](./cip-2.md).
+If you would like to become a UIP editor, please check [UIP-2](./uip-2.md).
 
 ## UIP Editor Responsibilities
 

--- a/uips/uip-2.md
+++ b/uips/uip-2.md
@@ -1,13 +1,13 @@
-| cip | 2 |
-| - | - |
-| title | UIP Editor Handbook |
-| description | Handy reference for UIP editors and those who want to become one |
-| author | Henry de Valence <hdevalence@penumbralabs.xyz> |
-| discussions-to | <https://forum.celestia.org> |
-| status | Draft |
-| type | Informational |
-| created | 2024-11-01 |
-| requires | UIP-1 |
+| uip            | 2                                                                |
+| -------------- | ---------------------------------------------------------------- |
+| title          | UIP Editor Handbook                                              |
+| description    | Handy reference for UIP editors and those who want to become one |
+| author         | Henry de Valence <hdevalence@penumbralabs.xyz>                   |
+| discussions-to | <https://forum.penumbra.zone>                                    |
+| status         | Draft                                                            |
+| type           | Informational                                                    |
+| created        | 2024-11-01                                                       |
+| requires       | UIP-1                                                            |
 
 ## Abstract
 

--- a/uips/uip-3.md
+++ b/uips/uip-3.md
@@ -1,13 +1,13 @@
-| cip | 3 |
-| - | - |
-| title | Process for Approving External Resources |
-| description | Requirements and process for allowing new origins of external resources |
-| author | Henry de Valence <hdevalence@penumbralabs.xyz> |
-| discussions-to | <https://forum.celestia.org> |
-| status | Draft |
-| type | Meta |
-| created | 2024-11-01 |
-| requires | UIP-1 |
+| uip            | 3                                                                       |
+| -------------- | ----------------------------------------------------------------------- |
+| title          | Process for Approving External Resources                                |
+| description    | Requirements and process for allowing new origins of external resources |
+| author         | Henry de Valence <hdevalence@penumbralabs.xyz>                          |
+| discussions-to | <https://forum.penumbra.zone>                                           |
+| status         | Draft                                                                   |
+| type           | Meta                                                                    |
+| created        | 2024-11-01                                                              |
+| requires       | UIP-1                                                                   |
 
 ## Abstract
 


### PR DESCRIPTION
I noticed that there was a static JS resource being pulled in from Celestia still (https://github.com/penumbra-zone/UIPs/blob/main/theme/head.hbs#L1) that I didn't change as part of this because I wasn't sure which CDN we should mirror to.