### PR TITLE
ci: fix nix gha helpers

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
+          backend: buildjet
 
       - name: build static docroot
         run: nix develop --command just build

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -13,9 +13,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: install nix
-        uses: DeterminateSystems/nix-installer-action@main
-      - name: load nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+        uses: nixbuild/nix-quick-install-action@v28
+      - name: setup nix cache
+        uses: nix-community/cache-nix-action@v5
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
 
       - name: build static docroot
         run: nix develop --command just build

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -15,9 +15,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: install nix
-        uses: DeterminateSystems/nix-installer-action@main
-      - name: load nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+        uses: nixbuild/nix-quick-install-action@v28
+      - name: setup nix cache
+        uses: nix-community/cache-nix-action@v5
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
 
       - name: run linters
         run: nix develop --command just lint
@@ -32,9 +35,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: install nix
-        uses: DeterminateSystems/nix-installer-action@main
-      - name: load nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+        uses: nixbuild/nix-quick-install-action@v28
+      - name: setup nix cache
+        uses: nix-community/cache-nix-action@v5
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
 
       - name: build static docroot
         run: nix develop --command just build

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
+          backend: buildjet
 
       - name: run linters
         run: nix develop --command just lint
@@ -41,6 +42,7 @@ jobs:
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
+          backend: buildjet
 
       - name: build static docroot
         run: nix develop --command just build


### PR DESCRIPTION
Through the PZ GH org we've been using the community-maintained nix cache helpers, rather than the DeterminateSystems ones, and they've been reliable. Updating this repo to match.